### PR TITLE
Fix lexicon download name

### DIFF
--- a/Sentiment_Analysis.ipynb
+++ b/Sentiment_Analysis.ipynb
@@ -230,7 +230,7 @@
       "cell_type": "code",
       "source": [
         "import nltk\n",
-        "nltk.download('lexicon')"
+        "nltk.download('vader_lexicon')"
       ],
       "execution_count": 0,
       "outputs": [


### PR DESCRIPTION
just 'lexicon' gave a error, and you used vader_lexicon in video