### PR TITLE
Fixed to get the Extended Tweet

### DIFF
--- a/.ipynb_checkpoints/Sentiment_Analysis-checkpoint.ipynb
+++ b/.ipynb_checkpoints/Sentiment_Analysis-checkpoint.ipynb
@@ -82,9 +82,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## To get the full 280 characters from Tweet\n",
-    "\n",
-    "The below code will also get the full tweets from a retweeted status. This helps us to perform sentimental analysis on a complete tweet."
+    "## To get the full 280 characters from"
    ]
   },
   {


### PR DESCRIPTION
I have updated the code to get the complete 280 character tweets. We were previously getting 140 characters and rest was truncated. 
With the following changes, we can apply sentimental analysis on the complete tweet. Hope this is helpful.
Please go through the link for better understanding the structure of Twitter Objects:
https://developer.twitter.com/en/docs/tweets/data-dictionary/overview/tweet-object